### PR TITLE
Two tweaky things

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Call the exported function passing in the React and ReactDOM objects as well as 
 ```
 var React = require('react');
 var ReactDOM = require('react-dom');
-var a11y = require('react-axe');
+var axe = require('react-axe');
 
-a11y(React, ReactDOM, 1000);
+axe(React, ReactDOM, 1000);
 ```
 
 Once initialized like this, the module will output accessibility defect information to the Chrome Devtools console every time a component updates.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ axe(React, ReactDOM, 1000);
 
 Once initialized like this, the module will output accessibility defect information to the Chrome Devtools console every time a component updates.
 
+## Run the example
+
+Run a build in the example directory and start a server to see React-aXe in action in the Chrome Devtools console (opens on localhost:8888):
+```
+cd example
+npm install
+npm start
+```
+
 ## Compatibility
 
 react-axe uses advanced console logging features and only works in the Chrome browser

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,8 @@
   "description": "Example of react-axe with a React.js application",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "grunt default && http-server -u localhost -p 8888"
   },
   "author": "Dylan Barrell (dylan@barrell.com)",
   "license": "MIT",
@@ -18,6 +19,7 @@
     "babel-preset-react": "^6.5.0",
     "grunt": "^1.0.1",
     "grunt-babel": "^6.0.0",
-    "grunt-browserify": "^5.0.0"
+    "grunt-browserify": "^5.0.0",
+    "http-server": "^0.9.0"
   }
 }

--- a/example/src/example.js
+++ b/example/src/example.js
@@ -1,9 +1,9 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
-// var a11y = require('react-axe');
-var a11y = require('../../index.js');
 
-a11y(React, ReactDOM, 1000);
+var axe = require('../../index.js');
+
+axe(React, ReactDOM, 1000);
 // This is more complex example that uses two components -
 // a service chooser form, and the individual services inside it.
 


### PR DESCRIPTION
I checked out the project and stumbled a little on the example setup, so I updated the README and added a server step for the example. Also changed `a11y` to `axe` since there is already a package by that name that uses the Chrome A11y Dev Tools.