### PR TITLE
Don't use rest parameters to prevent errors in Safari 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ npm start
 
 ## Compatibility
 
-react-axe uses advanced console logging features and only works in the Chrome browser
+react-axe uses advanced console logging features and works best in the Chrome browser, with limited functionality in Safari and Firefox.
 
 ## Advantages
 

--- a/after.js
+++ b/after.js
@@ -5,8 +5,8 @@ var after = function after(host, name, cb) {
   var restoreFn = undefined;
 
   if (originalFn) {
-    host[name] = function(...args) {
-      originalFn.apply(this, args);
+    host[name] = function() {
+      originalFn.apply(this, arguments);
       cb(host);
     };
     restoreFn = function () {

--- a/index.js
+++ b/index.js
@@ -140,8 +140,8 @@ var reactAxe = function reactAxe(_React, _ReactDOM, _timeout, conf) {
 	if (!_createElement) {
 		_createElement = React.createElement;
 
-		React.createElement = function (type, props, ...children) {
-			var reactEl = _createElement.apply(this, [type, props].concat(children));
+		React.createElement = function () {
+			var reactEl = _createElement.apply(this, arguments);
 
 			if(reactEl._owner && reactEl._owner._instance){
 				addComponent(reactEl._owner._instance);


### PR DESCRIPTION
Safari 9 doesn't support rest parameters :(